### PR TITLE
Add name when creating order

### DIFF
--- a/src/lib/create-order.ts
+++ b/src/lib/create-order.ts
@@ -10,6 +10,7 @@ const createOrder = async ({
   shippingRateUserDefinedId,
 }: SnipcartWebhookContent) => {
   const recipient = {
+    ...(shippingAddress.name && {name: shippingAddress.name},
     ...(shippingAddress.address1 && { address1: shippingAddress.address1 }),
     ...(shippingAddress.address2 && { address2: shippingAddress.address2 }),
     ...(shippingAddress.city && { city: shippingAddress.city }),


### PR DESCRIPTION
Not sure if this was omitted on purpose, but it makes the printful integration easier. 
Atm, new orders are created as draft orders, because the name is missing. This should make the order integration with Printful easier.