### PR TITLE
Handle new event - "customauth:customer_updated"

### DIFF
--- a/src/pages/api/snipcart/webhook.ts
+++ b/src/pages/api/snipcart/webhook.ts
@@ -5,7 +5,7 @@ import createOrder from "../../../lib/create-order";
 import type { SnipcartRequest, SnipcartWebhookEvent } from "../../../types";
 
 export default async (req: SnipcartRequest, res: NextApiResponse) => {
-  const allowedEvents: SnipcartWebhookEvent[] = ["order.completed"];
+  const allowedEvents: SnipcartWebhookEvent[] = ["order.completed", "customauth:customer_updated"];
 
   console.log(req.headers);
   const token = req.headers["x-snipcart-requesttoken"];
@@ -40,6 +40,10 @@ export default async (req: SnipcartRequest, res: NextApiResponse) => {
       case "order.completed":
         await createOrder(content);
         break;
+      case "customauth:customer_updated":
+        return res
+          .status(200)
+          .json({ message: "Customer updated - no action taken" });
       default:
         throw new Error("No such event handler exists");
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,8 @@ export type SnipcartWebhookEvent =
   | "subscription.resumed"
   | "subscription.invoice.created"
   | "shippingrates.fetch"
-  | "taxes.calculate";
+  | "taxes.calculate"
+  | "customauth:customer_updated";
 
 export interface SnipcartWebhookContent {
   discounts: { [key: string]: any };


### PR DESCRIPTION
I keep getting error 400 on Snipcart due to the webhook with this event getting declined. Added a handler that just returns a string saying no action was taken.